### PR TITLE
US127139: added d2l-dialog-fullscreen to IFrame test page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hello-world-fra-iframe",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Sample IFRAME-based free-range application",
   "appId": "urn:d2l:fra:id:hello-world-fra-iframe",
   "main": "src/index.html",

--- a/src/hello-world-app.js
+++ b/src/hello-world-app.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/button/button.js';
 import '@brightspace-ui/core/components/demo/code-view.js';
 import '@brightspace-ui/core/components/dialog/dialog-confirm.js';
-import '@brightspace-ui/core/components/dialog/dialog-fullscreen';
+import '@brightspace-ui/core/components/dialog/dialog-fullscreen.js';
 import '@brightspace-ui/core/components/typography/typography.js';
 import '@brightspace-ui/htmleditor/htmleditor.js';
 import { LitElement, html, css } from 'lit-element';
@@ -85,8 +85,8 @@ export class HelloWorldApp extends LitElement {
 			<d2l-button @click="${this._openConfirmDialog}">Open Confirm Dialog</d2l-button>
 
 			<h2>Fullscreen Dialog</h2>
-			<d2l-dialog-fullscreen id="dialog" title-text="Fullscreen Dialog">
-				<div id="top">Top of Dialog</div>
+			<d2l-dialog-fullscreen title-text="Fullscreen Dialog">
+				<div>Top of Dialog</div>
 				<div>Line 1</div>
 				<div>Line 2</div>
 				<div>Line 3</div>

--- a/src/hello-world-app.js
+++ b/src/hello-world-app.js
@@ -1,6 +1,7 @@
 import '@brightspace-ui/core/components/button/button.js';
 import '@brightspace-ui/core/components/demo/code-view.js';
 import '@brightspace-ui/core/components/dialog/dialog-confirm.js';
+import '@brightspace-ui/core/components/dialog/dialog-fullscreen';
 import '@brightspace-ui/core/components/typography/typography.js';
 import '@brightspace-ui/htmleditor/htmleditor.js';
 import { LitElement, html, css } from 'lit-element';
@@ -76,12 +77,25 @@ export class HelloWorldApp extends LitElement {
 			<h1>Hello World</h1>
 			<p>This is a simple free-range application demonstrating an IFRAME-based app.</p>
 
-			<h2>Dialogs</h2>
+			<h2>Confirm Dialog</h2>
 			<d2l-dialog-confirm title-text="Confirm Dialog" text="Are you sure?">
 				<d2l-button slot="footer" primary data-dialog-action="yes">Yes</d2l-button>
 				<d2l-button slot="footer" data-dialog-action>No</d2l-button>
 			</d2l-dialog-confirm>
-			<d2l-button @click="${this._openDialog}">Open Dialog</d2l-button>
+			<d2l-button @click="${this._openConfirmDialog}">Open Confirm Dialog</d2l-button>
+
+			<h2>Fullscreen Dialog</h2>
+			<d2l-dialog-fullscreen id="dialog" title-text="Fullscreen Dialog">
+				<div id="top">Top of Dialog</div>
+				<div>Line 1</div>
+				<div>Line 2</div>
+				<div>Line 3</div>
+				<div>Line 4</div>
+				<div>Bottom</div>
+				<d2l-button slot="footer" primary data-dialog-action="save">Save</d2l-button>
+				<d2l-button slot="footer" data-dialog-action>Cancel</d2l-button>
+			</d2l-dialog-fullscreen>
+			<d2l-button @click="${this._openFullscreenDialog}">Open Fullscreen Dialog</d2l-button>
 
 			<h2>Runtime data provided via ifrau:</h2>
 			${code}
@@ -116,8 +130,12 @@ export class HelloWorldApp extends LitElement {
 		}
 	}
 
-	_openDialog() {
+	_openConfirmDialog() {
 		this.shadowRoot.querySelector('d2l-dialog-confirm').opened = true;
+	}
+
+	_openFullscreenDialog() {
+		this.shadowRoot.querySelector('d2l-dialog-fullscreen').opened = true;
 	}
 
 }


### PR DESCRIPTION
I added the d2l-dialog-fullscreen component to the test page, so we can double-check any changes to the dialog will still work in an IFrame. 

New d2l-dialog-fullscreen component (not yet merged):
![ifrau_newfullscreen](https://user-images.githubusercontent.com/83968927/118679291-c36ee180-b7cb-11eb-8c19-663261500283.PNG)

How the d2l-dialog-fullscreen component looks now:
![ifrau_oldfullscreen](https://user-images.githubusercontent.com/83968927/118679292-c4077800-b7cb-11eb-9c19-35ab51fd5733.PNG)

The test page with the new content: 
![ifrau_page](https://user-images.githubusercontent.com/83968927/118679294-c4077800-b7cb-11eb-98eb-ba94e04e42a1.PNG)
