### PR TITLE
Add support for dynamic imports (needed by the HTML editor)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@brightspace-ui/core": "^1",
     "@brightspace-ui/htmleditor": "^1",
     "@open-wc/building-rollup": "^1",
+    "@rollup/plugin-dynamic-import-vars": "^1.1.1",
     "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
     "d2l-fetch-auth": "^1",
     "es-dev-server": "^2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import copy from 'rollup-plugin-copy';
+import dynamicImportVars from '@rollup/plugin-dynamic-import-vars';
 import merge from 'deepmerge';
 import { createSpaConfig } from '@open-wc/building-rollup';
 
@@ -22,6 +23,9 @@ export default merge(baseConfig, {
 				return {src: f, dest: 'dist/node_modules'};
 			}),
 			flatten: false
+		}),
+		dynamicImportVars({
+			include: 'node_modules/@brightspace-ui/htmleditor/**/*.js'
 		})
 	]
 });


### PR DESCRIPTION
The HTML editor now uses dynamic imports, which rollup doesn't support out of the box.